### PR TITLE
Add some more tools from GA config

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -10,9 +10,23 @@ tools:
     rules: []
     rank: |
       helpers.weighted_random_sampling(candidate_destinations)
+  testtoolshed.g2.bx.psu.edu/repos/fubar/htseq_bams_to_count_matrix/htseqsams2mxlocal/.*:
+    cores: 3
+  testtoolshed.g2.bx.psu.edu/repos/jchung/generate_count_matrix/generate_count_matrix/.*:
+    cores: 2
+  testtoolshed.g2.bx.psu.edu/repos/simon-gladman/phyloseq_filter/biom_filter/.*:
+    cores: 16
+  testtoolshed.g2.bx.psu.edu/repos/simon-gladman/phyloseq_ordination_plot/phyloseq_ordinate/.*:
+    cores: 16
+  toolshed.g2.bx.psu.edu/repos/artbio/repenrich/repenrich/.*:
+    cores: 8
+  toolshed.g2.bx.psu.edu/repos/bebatut/cdhit/cd_hit_est/.*:
+    cores: 4
   toolshed.g2.bx.psu.edu/repos/bgruening/alevin/alevin/.*:
     cores: 8
     mem: 92
+  toolshed.g2.bx.psu.edu/repos/bgruening/augustus/augustus/.*:
+    cores: 8
   toolshed.g2.bx.psu.edu/repos/bgruening/bigwig_to_bedgraph/bigwig_to_bedgraph/.*:
     mem: 12
   toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/.*:
@@ -176,6 +190,8 @@ tools:
   toolshed.g2.bx.psu.edu/repos/bgruening/infernal/infernal_cmsearch/.*:
     cores: 10
     mem: 20
+  toolshed.g2.bx.psu.edu/repos/bgruening/interproscan/interproscan/.*:
+    cores: 8
   toolshed.g2.bx.psu.edu/repos/bgruening/keras_train_and_eval/keras_train_and_eval/.*:
     cores: 4
     env:
@@ -194,6 +210,8 @@ tools:
   toolshed.g2.bx.psu.edu/repos/bgruening/nanopolish_methylation/nanopolish_methylation/.*:
     cores: 5
     mem: 12
+  toolshed.g2.bx.psu.edu/repos/bgruening/nanopolish_polya/nanopolish_polya/.*:
+    cores: 3
   toolshed.g2.bx.psu.edu/repos/bgruening/nanopolish_variants/nanopolish_variants/.*:
     cores: 5
     mem: 12
@@ -211,6 +229,8 @@ tools:
     mem: 36
   toolshed.g2.bx.psu.edu/repos/bgruening/rdock_sort_filter/rdock_sort_filter/.*:
     mem: 90
+  toolshed.g2.bx.psu.edu/repos/bgruening/repeat_masker/repeatmasker_wrapper/.*:
+    cores: 8
   toolshed.g2.bx.psu.edu/repos/bgruening/rxdock_sort_filter/rxdock_sort_filter/.*:
     mem: 90
   toolshed.g2.bx.psu.edu/repos/bgruening/sailfish/sailfish/.*:
@@ -258,6 +278,8 @@ tools:
   toolshed.g2.bx.psu.edu/repos/chemteam/gmx_fep/gmx_fep/.*:
     cores: 16
     mem: 8
+  toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/.*:
+    cores: 8
   toolshed.g2.bx.psu.edu/repos/chemteam/mdanalysis_extract_rmsd/mdanalysis_extract_rmsd/.*:
     cores: 4
     mem: 16
@@ -294,6 +316,8 @@ tools:
   toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/.*:
     cores: 8
     mem: 30
+  toolshed.g2.bx.psu.edu/repos/devteam/clustalw/clustalw/.*:
+    cores: 9
   toolshed.g2.bx.psu.edu/repos/devteam/cuffcompare/cuffcompare/.*:
     mem: 10
   toolshed.g2.bx.psu.edu/repos/devteam/cuffdiff/cuffdiff/.*:
@@ -312,6 +336,14 @@ tools:
     mem: 20
   'toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: fuzztran39/.*':
     mem: 10
+  toolshed.g2.bx.psu.edu/repos/devteam/fastq_groomer/fastq_groomer/.*:
+    cores: 2
+  toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_deinterlacer/fastq_paired_end_deinterlacer/.*:
+    cores: 8
+  toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_interlacer/fastq_paired_end_interlacer/.*:
+    cores: 8
+  toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_joiner/fastq_paired_end_joiner/.*:
+    cores: 3
   toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/.*:
     cores: 8
   toolshed.g2.bx.psu.edu/repos/devteam/fastx_collapser/cshl_fastx_collapser/.*:
@@ -319,9 +351,13 @@ tools:
   toolshed.g2.bx.psu.edu/repos/devteam/freebayes/freebayes/.*:
     cores: 10
     mem: 90
+  toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/.*:
+    cores: 9
   toolshed.g2.bx.psu.edu/repos/devteam/hisat/hisat/.*:
     cores: 10
     mem: 20
+  toolshed.g2.bx.psu.edu/repos/devteam/join/gops_join_1/.*:
+    cores: 5
   toolshed.g2.bx.psu.edu/repos/devteam/kraken/kraken/.*:
     mem: 90
   toolshed.g2.bx.psu.edu/repos/devteam/lastz/lastz_wrapper_2/.*:
@@ -348,6 +384,12 @@ tools:
   toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_tblastn_wrapper/.*:
     cores: 10
     mem: 40
+  toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_tblastx_wrapper/.*:
+    cores: 16
+  toolshed.g2.bx.psu.edu/repos/devteam/picard/.*:
+    cores: 3
+    env:
+      _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
   toolshed.g2.bx.psu.edu/repos/devteam/picard/PicardASMetrics/.*:
     mem: 12
     env:
@@ -408,6 +450,12 @@ tools:
     mem: 12
     env:
       _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
+  toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/.*:
+    cores: 3
+  toolshed.g2.bx.psu.edu/repos/devteam/samtools_mpileup/samtools_mpileup/.*:
+    cores: 5
+  toolshed.g2.bx.psu.edu/repos/devteam/samtools_rmdup/samtools_rmdup/.*:
+    cores: 2
   toolshed.g2.bx.psu.edu/repos/devteam/samtools_sort/samtools_sort/.*:
     cores: 10
     mem: 10
@@ -439,6 +487,12 @@ tools:
     mem: 12
   toolshed.g2.bx.psu.edu/repos/ethevenot/qualitymetrics/quality_metrics/.*:
     mem: 12
+  toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/.*:
+    cores: 8
+  toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_cactus/cactus_cactus/.*:
+    cores: 60
+  toolshed.g2.bx.psu.edu/repos/galaxy-australia/hifiadapterfilt/hifiadapterfilt/.*:
+    cores: 12
   toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_classification/cardinal_classification/.*:
     mem: 90
   toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_combine/cardinal_combine/.*:
@@ -476,6 +530,10 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxyp/mass_spectrometry_imaging_segmentations/mass_spectrometry_imaging_segmentations/.*:
     mem: 92
   toolshed.g2.bx.psu.edu/repos/galaxyp/maxquant/maxquant/.*:
+    cores: 16
+  toolshed.g2.bx.psu.edu/repos/galaxyp/maxquant/maxquant_mqpar/.*:
+    cores: 16
+  toolshed.g2.bx.psu.edu/repos/galaxyp/maxquant_mqpar/maxquant_mqpar/.*:
     cores: 16
   toolshed.g2.bx.psu.edu/repos/galaxyp/metagene_annotator/metagene_annotator/.*:
     mem: 16
@@ -865,6 +923,8 @@ tools:
     mem: 10
   toolshed.g2.bx.psu.edu/repos/imgteam/projective_transformation/ip_projective_transformation/.*:
     mem: 24
+  toolshed.g2.bx.psu.edu/repos/iuc/abricate/abricate/.*:
+    cores: 8
   toolshed.g2.bx.psu.edu/repos/iuc/abyss/abyss-pe/.*:
     cores: 20
     mem: 70
@@ -876,6 +936,12 @@ tools:
     cores: 4
   toolshed.g2.bx.psu.edu/repos/iuc/anndata_manipulate/anndata_manipulate/.*:
     cores: 4
+  toolshed.g2.bx.psu.edu/repos/iuc/barrnap/barrnap/.*:
+    cores: 3
+  toolshed.g2.bx.psu.edu/repos/iuc/bcftools_mpileup/bcftools_mpileup/.*:
+    cores: 7
+  toolshed.g2.bx.psu.edu/repos/iuc/bcftools_norm/bcftools_norm/.*:
+    cores: 2
   toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_intersectbed/.*:
     mem: 40
   toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_mergebed/.*:
@@ -899,6 +965,10 @@ tools:
     mem: 24
   toolshed.g2.bx.psu.edu/repos/iuc/circos/circgraph/.*:
     mem: 10
+  toolshed.g2.bx.psu.edu/repos/iuc/circos/circos/.*:
+    cores: 2
+  toolshed.g2.bx.psu.edu/repos/iuc/circos/circos_bundlelinks/.*:
+    cores: 5
   toolshed.g2.bx.psu.edu/repos/iuc/concoct/concoct/.*:
     cores: 10
     mem: 48
@@ -911,11 +981,19 @@ tools:
       - singularity
   toolshed.g2.bx.psu.edu/repos/iuc/deseq2/deseq2/.*:
     mem: 8
+  toolshed.g2.bx.psu.edu/repos/iuc/dexseq/dexseq/.*:
+    cores: 9
   toolshed.g2.bx.psu.edu/repos/iuc/dexseq/dexseq_count/.*:
     mem: 25
   toolshed.g2.bx.psu.edu/repos/iuc/drep_dereplicate/drep_dereplicate/.*:
     cores: 6
     mem: 12
+  toolshed.g2.bx.psu.edu/repos/iuc/edger/edger/.*:
+    cores: 5
+  toolshed.g2.bx.psu.edu/repos/iuc/exonerate/exonerate/.*:
+    cores: 30
+  toolshed.g2.bx.psu.edu/repos/iuc/fasta_stats/fasta-stats/.*:
+    cores: 3
   toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/.*:
     cores: 2
   toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/.*:
@@ -966,11 +1044,15 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/gatk2/gatk2_variant_validate/.*:
     cores: 10
     mem: 24
+  toolshed.g2.bx.psu.edu/repos/iuc/gecko/gecko/.*:
+    cores: 8
   toolshed.g2.bx.psu.edu/repos/iuc/gemini_load/gemini_load/.*:
     cores: 10
     mem: 40
   toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_heatmap2/ggplot2_heatmap2/.*:
     mem: 24
+  toolshed.g2.bx.psu.edu/repos/iuc/gubbins/gubbins/.*:
+    cores: 16
   toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/.*:
     cores: 8
     mem: 20
@@ -1021,11 +1103,17 @@ tools:
     cores: 8
   toolshed.g2.bx.psu.edu/repos/iuc/iqtree/iqtree/.*:
     cores: 10
+  toolshed.g2.bx.psu.edu/repos/iuc/ivar_consensus/ivar_consensus/.*:
+    cores: 8
   toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/.*:
     cores: 8
     scheduling:
       accept:
       - pulsar
+  toolshed.g2.bx.psu.edu/repos/iuc/ivar_variants/ivar_variants/.*:
+    cores: 8
+  toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/.*:
+    cores: 3
   toolshed.g2.bx.psu.edu/repos/iuc/jellyfish/jellyfish/.*:
     mem: 12
   toolshed.g2.bx.psu.edu/repos/iuc/kallisto_quant/kallisto_quant/.*:
@@ -1043,6 +1131,12 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/.*:
     cores: 2
     mem: 8
+  toolshed.g2.bx.psu.edu/repos/iuc/lofreq_filter/lofreq_filter/.*:
+    cores: 4
+  toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/.*:
+    cores: 3
+  toolshed.g2.bx.psu.edu/repos/iuc/lofreq_viterbi/lofreq_viterbi/.*:
+    cores: 4
   toolshed.g2.bx.psu.edu/repos/iuc/lumpy_sv/lumpy_sv/.*:
     mem: 8
   toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_bdgdiff/.*:
@@ -1072,6 +1166,8 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/metabat2/metabat2/.*:
     cores: 10
     mem: 48
+  toolshed.g2.bx.psu.edu/repos/iuc/metaphlan/metaphlan/.*:
+    cores: 16
   toolshed.g2.bx.psu.edu/repos/iuc/minimap2/minimap2/.*:
     cores: 8
     mem: 32
@@ -1137,6 +1233,8 @@ tools:
     mem: 20
     env:
       TERM: vt100
+  toolshed.g2.bx.psu.edu/repos/iuc/mothur_chimera_vsearch/mothur_chimera_vsearch/.*:
+    cores: 7
   toolshed.g2.bx.psu.edu/repos/iuc/mothur_chop_seqs/mothur_chop_seqs/.*:
     cores: 2
     mem: 20
@@ -1667,6 +1765,8 @@ tools:
     mem: 20
     env:
       TERM: vt100
+  toolshed.g2.bx.psu.edu/repos/iuc/mothur_taxonomy_to_krona/mothur_taxonomy_to_krona/.*:
+    cores: 7
   toolshed.g2.bx.psu.edu/repos/iuc/mothur_tree_shared/mothur_tree_shared/.*:
     cores: 2
     mem: 20
@@ -1704,6 +1804,10 @@ tools:
       TERM: vt100
   toolshed.g2.bx.psu.edu/repos/iuc/msaboot/msaboot/.*:
     mem: 6
+  toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/.*:
+    cores: 3
+  toolshed.g2.bx.psu.edu/repos/iuc/mummer_nucmer/mummer_nucmer/.*:
+    cores: 5
   toolshed.g2.bx.psu.edu/repos/iuc/nanocompore_sampcomp/nanocompore_sampcomp/.*:
     cores: 9
     mem: 48
@@ -1721,15 +1825,45 @@ tools:
     mem: 8
   toolshed.g2.bx.psu.edu/repos/iuc/pangolin/pangolin/.*:
     cores: 8
+  toolshed.g2.bx.psu.edu/repos/iuc/pear/iuc_pear/.*:
+    cores: 7
   toolshed.g2.bx.psu.edu/repos/iuc/pilon/pilon/.*:
     mem: 32
     env:
       _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
   toolshed.g2.bx.psu.edu/repos/iuc/porechop/porechop/.*:
     mem: 40
+  toolshed.g2.bx.psu.edu/repos/iuc/poretools_events/poretools_events/.*:
+    cores: 3
+  toolshed.g2.bx.psu.edu/repos/iuc/poretools_extract/poretools_extract/.*:
+    cores: 3
+  toolshed.g2.bx.psu.edu/repos/iuc/poretools_hist/poretools_hist/.*:
+    cores: 3
+  toolshed.g2.bx.psu.edu/repos/iuc/poretools_nucdist/poretools_nucdist/.*:
+    cores: 3
+  toolshed.g2.bx.psu.edu/repos/iuc/poretools_occupancy/poretools_occupancy/.*:
+    cores: 3
+  toolshed.g2.bx.psu.edu/repos/iuc/poretools_qualdist/poretools_qualdist/.*:
+    cores: 3
+  toolshed.g2.bx.psu.edu/repos/iuc/poretools_qualpos/poretools_qualpos/.*:
+    cores: 3
+  toolshed.g2.bx.psu.edu/repos/iuc/poretools_squiggle/poretools_squiggle/.*:
+    cores: 3
+  toolshed.g2.bx.psu.edu/repos/iuc/poretools_stats/poretools_stats/.*:
+    cores: 3
+  toolshed.g2.bx.psu.edu/repos/iuc/poretools_tabular/poretools_tabular/.*:
+    cores: 3
+  toolshed.g2.bx.psu.edu/repos/iuc/poretools_times/poretools_times/.*:
+    cores: 3
+  toolshed.g2.bx.psu.edu/repos/iuc/poretools_winner/poretools_winner/.*:
+    cores: 3
+  toolshed.g2.bx.psu.edu/repos/iuc/poretools_yield_plot/poretools_yield_plot/.*:
+    cores: 3
   toolshed.g2.bx.psu.edu/repos/iuc/pureclip/pureclip/.*:
     cores: 2
     mem: 32
+  toolshed.g2.bx.psu.edu/repos/iuc/purge_dups/purge_dups/.*:
+    cores: 8
   toolshed.g2.bx.psu.edu/repos/iuc/qualimap_bamqc/qualimap_bamqc/.*:
     mem: 24
   toolshed.g2.bx.psu.edu/repos/iuc/qualimap_rnaseq/qualimap_rnaseq/.*:
@@ -1737,6 +1871,10 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/quast/quast/.*:
     cores: 10
     mem: 12
+  toolshed.g2.bx.psu.edu/repos/iuc/raven/raven/.*:
+    cores: 16
+  toolshed.g2.bx.psu.edu/repos/iuc/raxml/raxml/.*:
+    cores: 16
   toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/.*:
     cores: 10
     mem: 90
@@ -1751,6 +1889,16 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/salsa/salsa/.*:
     cores: 1
     mem: 12
+  toolshed.g2.bx.psu.edu/repos/iuc/scanpy_cluster_reduce_dimension/scanpy_cluster_reduce_dimension/.*:
+    cores: 5
+  toolshed.g2.bx.psu.edu/repos/iuc/scanpy_filter/scanpy_filter/.*:
+    cores: 3
+  toolshed.g2.bx.psu.edu/repos/iuc/scanpy_inspect/scanpy_inspect/.*:
+    cores: 5
+  toolshed.g2.bx.psu.edu/repos/iuc/scanpy_normalize/scanpy_normalize/.*:
+    cores: 2
+  toolshed.g2.bx.psu.edu/repos/iuc/scanpy_remove_confounders/scanpy_remove_confounders/.*:
+    cores: 9
   toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schicadjustmatrix/schicexplorer_schicadjustmatrix/.*:
     cores: 5
     mem: 64
@@ -1799,6 +1947,8 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/scpipe/scpipe/.*:
     cores: 8
     mem: 64
+  toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_seq/.*:
+    cores: 4
   toolshed.g2.bx.psu.edu/repos/iuc/shasta/shasta/.*:
     cores: 10
     mem: 12
@@ -1858,11 +2008,29 @@ tools:
     cores: 8
   toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fastq_dump/.*:
     mem: 20
+  toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/sam_dump/.*:
+    cores: 3
   toolshed.g2.bx.psu.edu/repos/iuc/stacks2_clonefilter/stacks2_clonefilter/.*:
     mem: 8
+  toolshed.g2.bx.psu.edu/repos/iuc/stacks2_cstacks/stacks2_cstacks/.*:
+    cores: 16
   toolshed.g2.bx.psu.edu/repos/iuc/stacks2_denovomap/stacks2_denovomap/.*:
     cores: 4
     mem: 16
+  toolshed.g2.bx.psu.edu/repos/iuc/stacks2_gstacks/stacks2_gstacks/.*:
+    cores: 16
+  toolshed.g2.bx.psu.edu/repos/iuc/stacks2_kmerfilter/stacks2_kmerfilter/.*:
+    cores: 2
+  toolshed.g2.bx.psu.edu/repos/iuc/stacks2_populations/stacks2_populations/.*:
+    cores: 8
+  toolshed.g2.bx.psu.edu/repos/iuc/stacks2_refmap/stacks2_refmap/.*:
+    cores: 8
+  toolshed.g2.bx.psu.edu/repos/iuc/stacks2_shortreads/stacks2_shortreads/.*:
+    cores: 2
+  toolshed.g2.bx.psu.edu/repos/iuc/stacks2_sstacks/stacks2_sstacks/.*:
+    cores: 16
+  toolshed.g2.bx.psu.edu/repos/iuc/stacks2_ustacks/stacks2_ustacks/.*:
+    cores: 16
   toolshed.g2.bx.psu.edu/repos/iuc/stacks_clonefilter/stacks_clonefilter/.*:
     mem: 8
   toolshed.g2.bx.psu.edu/repos/iuc/strelka_germline/strelka_germline/.*:
@@ -1876,6 +2044,20 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/transdecoder/transdecoder/.*:
     cores: 8
     mem: 8
+  toolshed.g2.bx.psu.edu/repos/iuc/trinity/trinity/.*:
+    cores: 8
+  toolshed.g2.bx.psu.edu/repos/iuc/trinity_align_and_estimate_abundance/trinity_align_and_estimate_abundance/.*:
+    cores: 8
+  toolshed.g2.bx.psu.edu/repos/iuc/trycycler_cluster/trycycler_cluster/.*:
+    cores: 9
+  toolshed.g2.bx.psu.edu/repos/iuc/trycycler_consensus/trycycler_consensus/.*:
+    cores: 16
+  toolshed.g2.bx.psu.edu/repos/iuc/trycycler_partition/trycycler_partition/.*:
+    cores: 9
+  toolshed.g2.bx.psu.edu/repos/iuc/trycycler_reconcile_msa/trycycler_reconcile_msa/.*:
+    cores: 9
+  toolshed.g2.bx.psu.edu/repos/iuc/trycycler_subsample/trycycler_subsample/.*:
+    cores: 9
   toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_dedup/umi_tools_dedup/.*:
     mem: 90
   toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/.*:
@@ -1920,9 +2102,17 @@ tools:
   toolshed.g2.bx.psu.edu/repos/mbernt/maxbin2/maxbin2/.*:
     cores: 10
     mem: 48
+  toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_RPKM_saturation/.*:
+    cores: 8
   toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_bam2wig/.*:
     cores: 8
     mem: 16
+  toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_geneBody_coverage/.*:
+    cores: 2
+  toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_geneBody_coverage2/.*:
+    cores: 2
+  toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_read_distribution/.*:
+    cores: 2
   toolshed.g2.bx.psu.edu/repos/nml/metaspades/metaspades/.*:
     cores: 10
     mem: 250
@@ -1937,6 +2127,10 @@ tools:
     mem: 8
   toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/signalp3/.*:
     mem: 10
+  toolshed.g2.bx.psu.edu/repos/pjbriggs/macs21/macs2_1_peakcalling/.*:
+    cores: 9
+  toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/.*:
+    cores: 3
   toolshed.g2.bx.psu.edu/repos/rnateam/blockbuster/blockbuster/.*:
     mem: 64
   toolshed.g2.bx.psu.edu/repos/rnateam/blockclust/blockclust/.*:
@@ -1949,6 +2143,8 @@ tools:
     mem: 10
   toolshed.g2.bx.psu.edu/repos/rnateam/graphprot_predict_profile/graphprot_predict_profile/.*:
     mem: 16
+  toolshed.g2.bx.psu.edu/repos/rnateam/mafft/rbc_mafft/.*:
+    cores: 8
   toolshed.g2.bx.psu.edu/repos/rnateam/metilene/metilene/.*:
     cores: 10
     mem: 20
@@ -1975,26 +2171,48 @@ tools:
     mem: 80
   toolshed.g2.bx.psu.edu/repos/rnateam/sshmm/sshmm/.*:
     mem: 16
+  toolshed.g2.bx.psu.edu/repos/saskia-hiltemann/krona_text/krona-text/.*:
+    cores: 7
+  toolshed.g2.bx.psu.edu/repos/simon-gladman/velvetoptimiser/velvetoptimiser/.*:
+    cores: 4
   toolshed.g2.bx.psu.edu/repos/tyty/structurefold/iterative_map_pipeline/.*:
     mem: 60
+  toolshed.g2.bx.psu.edu/repos/wolma/mimodd_aln/mimodd_align/.*:
+    cores: 5
   toolshed.g2.bx.psu.edu/repos/wolma/mimodd_main/mimodd_varcall/.*:
     cores: 6
+  .*bowtie2_index_builder_data_manager.*:
+    cores: 16
   .*bwa_mem_index_builder_data_manager.*:
     cores: 12
     mem: 48
   .*bwameth_index_builder_data_manager.*:
     cores: 12
     mem: 92
+  .*data_manager.*:
+    cores: 5
   .*data_manager_build_kraken2_database.*:
     cores: 1
     mem: 64
+  .*data_manager_cat.*:
+    cores: 5
+  .*data_manager_diamond_database_builder.*:
+    cores: 5
+  .*data_manager_eggnog_mapper_abspath.*:
+    cores: 5
   .*data_manager_funannotate.*:
     cores: 1
     mem: 64
   .*data_manager_gemini_download.*:
     mem: 20
+  .*data_manager_humann2_database_downloader.*:
+    cores: 5
   .*data_manager_humann2_download.*:
     mem: 25
+  .*data_manager_humann_database_downloader.*:
+    cores: 5
+  .*data_manager_interproscan.*:
+    cores: 5
   .*data_manager_metaphlan_download.*:
     cores: 12
     mem: 92
@@ -2013,6 +2231,8 @@ tools:
   .*kallisto_index_builder_data_manager.*:
     cores: 12
     mem: 92
+  .*kraken2_build_database.*:
+    cores: 16
   .*kraken_database_builder.*:
     mem: 200
   .*picard_index_builder_data_manager.*:
@@ -2023,10 +2243,14 @@ tools:
   .*salmon_index_builder_data_manager.*:
     cores: 12
     mem: 92
+  .*twobit_builder_data_manager.*:
+    cores: 16
   CONVERTER_bedgraph_to_bigwig:
     mem: 8
   Extract genomic DNA 1:
     cores: 3
+  alphafold_test:
+    cores: 6
   bfast_wrapper:
     cores: 10
     mem: 20
@@ -2039,6 +2263,8 @@ tools:
     mem: 18
   re_he_maldi_image_registration:
     mem: 48
+  tabular_to_csv:
+    cores: 3
   tombo_detect_modifications:
     cores: 10
     mem: 32

--- a/tools.yml
+++ b/tools.yml
@@ -10,8 +10,6 @@ tools:
     rules: []
     rank: |
       helpers.weighted_random_sampling(candidate_destinations)
-  testtoolshed.g2.bx.psu.edu/repos/fubar/htseq_bams_to_count_matrix/htseqsams2mxlocal/.*:
-    cores: 3
   testtoolshed.g2.bx.psu.edu/repos/jchung/generate_count_matrix/generate_count_matrix/.*:
     cores: 2
   testtoolshed.g2.bx.psu.edu/repos/simon-gladman/phyloseq_filter/biom_filter/.*:
@@ -487,8 +485,6 @@ tools:
     mem: 12
   toolshed.g2.bx.psu.edu/repos/ethevenot/qualitymetrics/quality_metrics/.*:
     mem: 12
-  toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/.*:
-    cores: 8
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_cactus/cactus_cactus/.*:
     cores: 60
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/hifiadapterfilt/hifiadapterfilt/.*:
@@ -2045,7 +2041,7 @@ tools:
     cores: 8
     mem: 8
   toolshed.g2.bx.psu.edu/repos/iuc/trinity/trinity/.*:
-    cores: 8
+    cores: 32
   toolshed.g2.bx.psu.edu/repos/iuc/trinity_align_and_estimate_abundance/trinity_align_and_estimate_abundance/.*:
     cores: 8
   toolshed.g2.bx.psu.edu/repos/iuc/trycycler_cluster/trycycler_cluster/.*:
@@ -2189,8 +2185,6 @@ tools:
   .*bwameth_index_builder_data_manager.*:
     cores: 12
     mem: 92
-  .*data_manager.*:
-    cores: 5
   .*data_manager_build_kraken2_database.*:
     cores: 1
     mem: 64
@@ -2249,8 +2243,6 @@ tools:
     mem: 8
   Extract genomic DNA 1:
     cores: 3
-  alphafold_test:
-    cores: 6
   bfast_wrapper:
     cores: 10
     mem: 20

--- a/tools.yml
+++ b/tools.yml
@@ -11,11 +11,11 @@ tools:
     rank: |
       helpers.weighted_random_sampling(candidate_destinations)
   testtoolshed.g2.bx.psu.edu/repos/jchung/generate_count_matrix/generate_count_matrix/.*:
-    cores: 2
+    mem: 7.6
   testtoolshed.g2.bx.psu.edu/repos/simon-gladman/phyloseq_filter/biom_filter/.*:
-    cores: 16
+    mem: 60.8
   testtoolshed.g2.bx.psu.edu/repos/simon-gladman/phyloseq_ordination_plot/phyloseq_ordinate/.*:
-    cores: 16
+    mem: 60.8
   toolshed.g2.bx.psu.edu/repos/artbio/repenrich/repenrich/.*:
     cores: 8
   toolshed.g2.bx.psu.edu/repos/bebatut/cdhit/cd_hit_est/.*:
@@ -24,7 +24,7 @@ tools:
     cores: 8
     mem: 92
   toolshed.g2.bx.psu.edu/repos/bgruening/augustus/augustus/.*:
-    cores: 8
+    mem: 30.4
   toolshed.g2.bx.psu.edu/repos/bgruening/bigwig_to_bedgraph/bigwig_to_bedgraph/.*:
     mem: 12
   toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/.*:
@@ -191,7 +191,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/bgruening/interproscan/interproscan/.*:
     cores: 8
   toolshed.g2.bx.psu.edu/repos/bgruening/keras_train_and_eval/keras_train_and_eval/.*:
-    cores: 4
+    mem: 15.2
     env:
       CUDA_VISIBLE_DEVICES: 0
   toolshed.g2.bx.psu.edu/repos/bgruening/minced/minced/.*:
@@ -241,7 +241,6 @@ tools:
     cores: 10
     mem: 12
   toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_searchcv/sklearn_searchcv/.*:
-    cores: 10
     mem: 12
   toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/.*:
     mem: 12
@@ -315,7 +314,7 @@ tools:
     cores: 8
     mem: 30
   toolshed.g2.bx.psu.edu/repos/devteam/clustalw/clustalw/.*:
-    cores: 9
+    mem: 34.2
   toolshed.g2.bx.psu.edu/repos/devteam/cuffcompare/cuffcompare/.*:
     mem: 10
   toolshed.g2.bx.psu.edu/repos/devteam/cuffdiff/cuffdiff/.*:
@@ -335,13 +334,13 @@ tools:
   'toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: fuzztran39/.*':
     mem: 10
   toolshed.g2.bx.psu.edu/repos/devteam/fastq_groomer/fastq_groomer/.*:
-    cores: 2
+    mem: 7.6
   toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_deinterlacer/fastq_paired_end_deinterlacer/.*:
-    cores: 8
+    mem: 30.4
   toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_interlacer/fastq_paired_end_interlacer/.*:
-    cores: 8
+    mem: 30.4
   toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_joiner/fastq_paired_end_joiner/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/.*:
     cores: 8
   toolshed.g2.bx.psu.edu/repos/devteam/fastx_collapser/cshl_fastx_collapser/.*:
@@ -350,12 +349,12 @@ tools:
     cores: 10
     mem: 90
   toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/.*:
-    cores: 9
+    mem: 34.2
   toolshed.g2.bx.psu.edu/repos/devteam/hisat/hisat/.*:
     cores: 10
     mem: 20
   toolshed.g2.bx.psu.edu/repos/devteam/join/gops_join_1/.*:
-    cores: 5
+    mem: 19.0
   toolshed.g2.bx.psu.edu/repos/devteam/kraken/kraken/.*:
     mem: 90
   toolshed.g2.bx.psu.edu/repos/devteam/lastz/lastz_wrapper_2/.*:
@@ -449,11 +448,11 @@ tools:
     env:
       _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
   toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/devteam/samtools_mpileup/samtools_mpileup/.*:
     cores: 5
   toolshed.g2.bx.psu.edu/repos/devteam/samtools_rmdup/samtools_rmdup/.*:
-    cores: 2
+    mem: 7.6
   toolshed.g2.bx.psu.edu/repos/devteam/samtools_sort/samtools_sort/.*:
     cores: 10
     mem: 10
@@ -461,7 +460,6 @@ tools:
     cores: 10
     mem: 90
   toolshed.g2.bx.psu.edu/repos/devteam/velvet/velvetg/.*:
-    cores: 4
     mem: 32
     env:
       OMP_NUM_THREADS: '{cores}'
@@ -901,7 +899,6 @@ tools:
     env:
       _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
   toolshed.g2.bx.psu.edu/repos/galaxyp/proteomics_moff/proteomics_moff/.*:
-    cores: 6
     mem: 20
   toolshed.g2.bx.psu.edu/repos/galaxyp/pyprophet_score/pyprophet_score/.*:
     cores: 1
@@ -920,7 +917,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/imgteam/projective_transformation/ip_projective_transformation/.*:
     mem: 24
   toolshed.g2.bx.psu.edu/repos/iuc/abricate/abricate/.*:
-    cores: 8
+    mem: 30.4
   toolshed.g2.bx.psu.edu/repos/iuc/abyss/abyss-pe/.*:
     cores: 20
     mem: 70
@@ -929,9 +926,9 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/anndata_import/anndata_import/.*:
     mem: 200
   toolshed.g2.bx.psu.edu/repos/iuc/anndata_inspect/anndata_inspect/.*:
-    cores: 4
+    mem: 15.2
   toolshed.g2.bx.psu.edu/repos/iuc/anndata_manipulate/anndata_manipulate/.*:
-    cores: 4
+    mem: 15.2
   toolshed.g2.bx.psu.edu/repos/iuc/barrnap/barrnap/.*:
     cores: 3
   toolshed.g2.bx.psu.edu/repos/iuc/bcftools_mpileup/bcftools_mpileup/.*:
@@ -962,9 +959,9 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/circos/circgraph/.*:
     mem: 10
   toolshed.g2.bx.psu.edu/repos/iuc/circos/circos/.*:
-    cores: 2
+    mem: 7.6
   toolshed.g2.bx.psu.edu/repos/iuc/circos/circos_bundlelinks/.*:
-    cores: 5
+    mem: 19.0
   toolshed.g2.bx.psu.edu/repos/iuc/concoct/concoct/.*:
     cores: 10
     mem: 48
@@ -985,11 +982,11 @@ tools:
     cores: 6
     mem: 12
   toolshed.g2.bx.psu.edu/repos/iuc/edger/edger/.*:
-    cores: 5
+    mem: 19.0
   toolshed.g2.bx.psu.edu/repos/iuc/exonerate/exonerate/.*:
     cores: 30
   toolshed.g2.bx.psu.edu/repos/iuc/fasta_stats/fasta-stats/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/.*:
     cores: 2
   toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/.*:
@@ -1041,7 +1038,7 @@ tools:
     cores: 10
     mem: 24
   toolshed.g2.bx.psu.edu/repos/iuc/gecko/gecko/.*:
-    cores: 8
+    mem: 30.4
   toolshed.g2.bx.psu.edu/repos/iuc/gemini_load/gemini_load/.*:
     cores: 10
     mem: 40
@@ -1100,16 +1097,16 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/iqtree/iqtree/.*:
     cores: 10
   toolshed.g2.bx.psu.edu/repos/iuc/ivar_consensus/ivar_consensus/.*:
-    cores: 8
+    mem: 30.4
   toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/.*:
     cores: 8
     scheduling:
       accept:
       - pulsar
   toolshed.g2.bx.psu.edu/repos/iuc/ivar_variants/ivar_variants/.*:
-    cores: 8
+    mem: 30.4
   toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/jellyfish/jellyfish/.*:
     mem: 12
   toolshed.g2.bx.psu.edu/repos/iuc/kallisto_quant/kallisto_quant/.*:
@@ -1128,9 +1125,9 @@ tools:
     cores: 2
     mem: 8
   toolshed.g2.bx.psu.edu/repos/iuc/lofreq_filter/lofreq_filter/.*:
-    cores: 4
+    mem: 15.2
   toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/lofreq_viterbi/lofreq_viterbi/.*:
     cores: 4
   toolshed.g2.bx.psu.edu/repos/iuc/lumpy_sv/lumpy_sv/.*:
@@ -1762,7 +1759,7 @@ tools:
     env:
       TERM: vt100
   toolshed.g2.bx.psu.edu/repos/iuc/mothur_taxonomy_to_krona/mothur_taxonomy_to_krona/.*:
-    cores: 7
+    mem: 26.6
   toolshed.g2.bx.psu.edu/repos/iuc/mothur_tree_shared/mothur_tree_shared/.*:
     cores: 2
     mem: 20
@@ -1801,7 +1798,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/msaboot/msaboot/.*:
     mem: 6
   toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/mummer_nucmer/mummer_nucmer/.*:
     cores: 5
   toolshed.g2.bx.psu.edu/repos/iuc/nanocompore_sampcomp/nanocompore_sampcomp/.*:
@@ -1830,36 +1827,36 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/porechop/porechop/.*:
     mem: 40
   toolshed.g2.bx.psu.edu/repos/iuc/poretools_events/poretools_events/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/poretools_extract/poretools_extract/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/poretools_hist/poretools_hist/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/poretools_nucdist/poretools_nucdist/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/poretools_occupancy/poretools_occupancy/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/poretools_qualdist/poretools_qualdist/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/poretools_qualpos/poretools_qualpos/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/poretools_squiggle/poretools_squiggle/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/poretools_stats/poretools_stats/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/poretools_tabular/poretools_tabular/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/poretools_times/poretools_times/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/poretools_winner/poretools_winner/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/poretools_yield_plot/poretools_yield_plot/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/pureclip/pureclip/.*:
     cores: 2
     mem: 32
   toolshed.g2.bx.psu.edu/repos/iuc/purge_dups/purge_dups/.*:
-    cores: 8
+    mem: 30.4
   toolshed.g2.bx.psu.edu/repos/iuc/qualimap_bamqc/qualimap_bamqc/.*:
     mem: 24
   toolshed.g2.bx.psu.edu/repos/iuc/qualimap_rnaseq/qualimap_rnaseq/.*:
@@ -1886,13 +1883,13 @@ tools:
     cores: 1
     mem: 12
   toolshed.g2.bx.psu.edu/repos/iuc/scanpy_cluster_reduce_dimension/scanpy_cluster_reduce_dimension/.*:
-    cores: 5
+    mem: 19.0
   toolshed.g2.bx.psu.edu/repos/iuc/scanpy_filter/scanpy_filter/.*:
-    cores: 3
+    mem: 11.4
   toolshed.g2.bx.psu.edu/repos/iuc/scanpy_inspect/scanpy_inspect/.*:
-    cores: 5
+    mem: 19.0
   toolshed.g2.bx.psu.edu/repos/iuc/scanpy_normalize/scanpy_normalize/.*:
-    cores: 2
+    mem: 7.6
   toolshed.g2.bx.psu.edu/repos/iuc/scanpy_remove_confounders/scanpy_remove_confounders/.*:
     cores: 9
   toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schicadjustmatrix/schicexplorer_schicadjustmatrix/.*:
@@ -2016,13 +2013,13 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/stacks2_gstacks/stacks2_gstacks/.*:
     cores: 16
   toolshed.g2.bx.psu.edu/repos/iuc/stacks2_kmerfilter/stacks2_kmerfilter/.*:
-    cores: 2
+    mem: 7.6
   toolshed.g2.bx.psu.edu/repos/iuc/stacks2_populations/stacks2_populations/.*:
     cores: 8
   toolshed.g2.bx.psu.edu/repos/iuc/stacks2_refmap/stacks2_refmap/.*:
     cores: 8
   toolshed.g2.bx.psu.edu/repos/iuc/stacks2_shortreads/stacks2_shortreads/.*:
-    cores: 2
+    mem: 7.6
   toolshed.g2.bx.psu.edu/repos/iuc/stacks2_sstacks/stacks2_sstacks/.*:
     cores: 16
   toolshed.g2.bx.psu.edu/repos/iuc/stacks2_ustacks/stacks2_ustacks/.*:
@@ -2038,7 +2035,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/.*:
     mem: 25
   toolshed.g2.bx.psu.edu/repos/iuc/transdecoder/transdecoder/.*:
-    cores: 8
     mem: 8
   toolshed.g2.bx.psu.edu/repos/iuc/trinity/trinity/.*:
     cores: 32
@@ -2099,16 +2095,15 @@ tools:
     cores: 10
     mem: 48
   toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_RPKM_saturation/.*:
-    cores: 8
+    mem: 30.4
   toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_bam2wig/.*:
-    cores: 8
     mem: 16
   toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_geneBody_coverage/.*:
-    cores: 2
+    mem: 7.6
   toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_geneBody_coverage2/.*:
-    cores: 2
+    mem: 7.6
   toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_read_distribution/.*:
-    cores: 2
+    mem: 7.6
   toolshed.g2.bx.psu.edu/repos/nml/metaspades/metaspades/.*:
     cores: 10
     mem: 250
@@ -2124,7 +2119,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/signalp3/.*:
     mem: 10
   toolshed.g2.bx.psu.edu/repos/pjbriggs/macs21/macs2_1_peakcalling/.*:
-    cores: 9
+    mem: 34.2
   toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/.*:
     cores: 3
   toolshed.g2.bx.psu.edu/repos/rnateam/blockbuster/blockbuster/.*:
@@ -2145,7 +2140,6 @@ tools:
     cores: 10
     mem: 20
   toolshed.g2.bx.psu.edu/repos/rnateam/mirdeep2_mapper/rbc_mirdeep2_mapper/.*:
-    cores: 10
     mem: 20
   toolshed.g2.bx.psu.edu/repos/rnateam/paralyzer/paralyzer/.*:
     mem: 8
@@ -2168,15 +2162,15 @@ tools:
   toolshed.g2.bx.psu.edu/repos/rnateam/sshmm/sshmm/.*:
     mem: 16
   toolshed.g2.bx.psu.edu/repos/saskia-hiltemann/krona_text/krona-text/.*:
-    cores: 7
+    mem: 26.6
   toolshed.g2.bx.psu.edu/repos/simon-gladman/velvetoptimiser/velvetoptimiser/.*:
     cores: 4
   toolshed.g2.bx.psu.edu/repos/tyty/structurefold/iterative_map_pipeline/.*:
     mem: 60
   toolshed.g2.bx.psu.edu/repos/wolma/mimodd_aln/mimodd_align/.*:
-    cores: 5
+    mem: 19.0
   toolshed.g2.bx.psu.edu/repos/wolma/mimodd_main/mimodd_varcall/.*:
-    cores: 6
+    mem: 22.8
   .*bowtie2_index_builder_data_manager.*:
     cores: 16
   .*bwa_mem_index_builder_data_manager.*:

--- a/tools.yml
+++ b/tools.yml
@@ -24,7 +24,7 @@ tools:
     cores: 8
     mem: 92
   toolshed.g2.bx.psu.edu/repos/bgruening/augustus/augustus/.*:
-    mem: 30.4
+    mem: 30
   toolshed.g2.bx.psu.edu/repos/bgruening/bigwig_to_bedgraph/bigwig_to_bedgraph/.*:
     mem: 12
   toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/.*:
@@ -315,7 +315,7 @@ tools:
     cores: 8
     mem: 30
   toolshed.g2.bx.psu.edu/repos/devteam/clustalw/clustalw/.*:
-    mem: 34.2
+    mem: 34
   toolshed.g2.bx.psu.edu/repos/devteam/cuffcompare/cuffcompare/.*:
     mem: 10
   toolshed.g2.bx.psu.edu/repos/devteam/cuffdiff/cuffdiff/.*:
@@ -485,7 +485,8 @@ tools:
   toolshed.g2.bx.psu.edu/repos/ethevenot/qualitymetrics/quality_metrics/.*:
     mem: 12
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_cactus/cactus_cactus/.*:
-    cores: 60
+    cores: 30
+    mem: 250
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/hifiadapterfilt/hifiadapterfilt/.*:
     cores: 12
   toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_classification/cardinal_classification/.*:
@@ -2250,8 +2251,6 @@ tools:
     mem: 18
   re_he_maldi_image_registration:
     mem: 48
-  tabular_to_csv:
-    cores: 3
   tombo_detect_modifications:
     cores: 10
     mem: 32

--- a/tools.yml
+++ b/tools.yml
@@ -191,7 +191,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/bgruening/interproscan/interproscan/.*:
     cores: 8
   toolshed.g2.bx.psu.edu/repos/bgruening/keras_train_and_eval/keras_train_and_eval/.*:
-    mem: 15.2
+    cores: 4
     env:
       CUDA_VISIBLE_DEVICES: 0
   toolshed.g2.bx.psu.edu/repos/bgruening/minced/minced/.*:
@@ -241,6 +241,7 @@ tools:
     cores: 10
     mem: 12
   toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_searchcv/sklearn_searchcv/.*:
+    cores: 10
     mem: 12
   toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/.*:
     mem: 12


### PR DESCRIPTION
These are tools from GA's tpv config that were not already in this file.  In the case that tools have file size rules on GA I have used the largest here, unless it is >30.  These tools do not have mem values as they are using the default `cores * 3.8` but I could update this PR with mem values if needed.