### PR TITLE
Fix antismash ID regex

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -28,7 +28,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/bgruening/alevin/alevin/.*:
     cores: 8
     mem: 92
-  toolshed.g2.bx.psu.edu/repos/bgruening/antismash/.*:
+  toolshed.g2.bx.psu.edu/repos/bgruening/antismash/antismash/.*:
     cores: 10
     mem: 90
     env:


### PR DESCRIPTION
The shared db has `toolshed.g2.bx.psu.edu/repos/bgruening/antismash/.*` and GA's config has `toolshed.g2.bx.psu.edu/repos/bgruening/antismash/antismash/.*` and GA inherits nothing from the shared db for antismash.

Since the second string fits the convention I'd like to change it here straight away to fix antismash on GA.

@nuwang is it intended that the tool would inherit properties from the shared db either way?