### PR TITLE
Pin galaxy-app <= 22.1.1 in linter requirements

### DIFF
--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,3 +1,3 @@
 total-perspective-vortex
 pyyaml
-galaxy-app
+galaxy-app<=22.1.1


### PR DESCRIPTION
'tpv lint' fails because of a new version of galaxy-app