### PR TITLE
Reduce allocation for featurecounts to 2c 8g

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -1149,8 +1149,8 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/.*:
     cores: 4
   toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/.*:
-    cores: 8
-    mem: 18
+    cores: 2
+    mem: 8
   toolshed.g2.bx.psu.edu/repos/iuc/feelnc/feelnc/.*:
     mem: 12
   toolshed.g2.bx.psu.edu/repos/iuc/filtlong/filtlong/.*:


### PR DESCRIPTION
featurecounts is a tool that never had entry in Galaxy Australia's tpv configuration because all jobs completed within 5 minutes with the default allocation of 1 CPU and 3.8G.
