### PR TITLE
Add entry for bellerophon

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -1078,6 +1078,9 @@ tools:
     mem: 20
   toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_subtractbed/.*:
     mem: 8
+  toolshed.g2.bx.psu.edu/repos/iuc/bellerophon/bellerophon/.*:
+    cores: 8
+    mem: 8
   toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/.*:
     cores: 16
     mem: 80


### PR DESCRIPTION
bellerophon is very slow with the default 1-core allocation. This PR sets cores to 8. It doesn't seem to need much RAM: from looking at 25 recent jobs with large inputs (12-90G), the max mem used was <1Gb per job.