### PR TITLE
Update tools.yml with recetox and ms tools

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -2359,6 +2359,10 @@ tools:
     mem: 32
   toolshed.g2.bx.psu.edu/repos/lecorguille/xcms_retcor/abims_xcms_retcor/.*:
     mem: 32
+  toolshed.g2.bx.psu.edu/repos/lecorguille/xcms_group/abims_xcms_group/.*:
+    mem: 32
+  toolshed.g2.bx.psu.edu/repos/lecorguille/xcms_merge/abims_xcms_merge/.*:
+    mem: 32
   toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/.*:
     cores: 5
   toolshed.g2.bx.psu.edu/repos/lparsons/htseq_count/htseq_count/.*:
@@ -2402,8 +2406,18 @@ tools:
     mem: 12
     env:
       _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
+  toolshed.g2.bx.psu.edu/repos/recetox/ramclustr/ramclustr/.*:
+    cores: 4
   toolshed.g2.bx.psu.edu/repos/recetox/recetox_aplcms_align_features/recetox_aplcms_align_features/.*:
     cores: 4
+  toolshed.g2.bx.psu.edu/repos/recetox/recetox_aplcms_compute_clusters/recetox_aplcms_compute_clusters/.*:
+    mem: 16
+  toolshed.g2.bx.psu.edu/repos/recetox/recetox_aplcms_generate_feature_table/recetox_aplcms_generate_feature_table/.*:
+    mem: 16
+  toolshed.g2.bx.psu.edu/repos/recetox/recetox_aplcms_recover_weaker_signals/recetox_aplcms_recover_weaker_signals/.*:
+    mem: 16
+  toolshed.g2.bx.psu.edu/repos/recetox/recetox_aplcms_remove_noise/recetox_aplcms_remove_noise/.*:
+    mem: 16
   toolshed.g2.bx.psu.edu/repos/rnateam/blockbuster/blockbuster/.*:
     mem: 64
   toolshed.g2.bx.psu.edu/repos/rnateam/blockclust/blockclust/.*:


### PR DESCRIPTION
This PR adds resource requirements for tools developed at RECETOX and othes used for general mass spectrometry.

The high memory requirements are only needed for larger files - we should add a smarter mechanism to determine those in the future using the dynamic scheduling. I think this is something we should follow up in the future.