### PR TITLE
Add entries for ebi-gxa anndata_ops and scanpy

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -566,6 +566,16 @@ tools:
       CACHE_4_TCOFFEE: $TMP
       DIR_4_TCOFFEE: $TMP
       TMP_4_TCOFFEE: $TMP
+  toolshed.g2.bx.psu.edu/repos/ebi-gxa/anndata_ops/anndata_ops/.*:
+    mem: 2 + input_size * 7
+  toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy.*:
+    mem: 4 + input_size * 10
+  toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_multiplet_scrublet/scanpy_multiplet_scrublet/.*:
+    mem: 1 + input_size * 65
+  toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_scale_data/scanpy_scale_data/.*:
+    mem: 1 + input_size * 32
+  toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/.*:
+    mem: 2 + input_size * 10
   toolshed.g2.bx.psu.edu/repos/ecology/srs_preprocess_s2/srs_preprocess_s2/.*:
     mem: 16
   toolshed.g2.bx.psu.edu/repos/ecology/xarray_select/xarray_select/.*:


### PR DESCRIPTION
Add scaling rules for some ebi-gxa tools.

Add a general fallback for ebi-gxa/scanpy* as well as specific ones for anndata_ops, scanpy_multiplet_scrublet, scanpy_scale_data and scanpy_run_pca.