### PR TITLE
add entry for bio3d_pca_visualize

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -317,6 +317,8 @@ tools:
     mem: 20
   toolshed.g2.bx.psu.edu/repos/chemteam/bio3d_pca/bio3d_pca/.*:
     mem: 64
+  toolshed.g2.bx.psu.edu/repos/chemteam/bio3d_pca_visualize/bio3d_pca_visualize/.*:
+    mem: 64
   toolshed.g2.bx.psu.edu/repos/chemteam/bio3d_rmsd/bio3d_rmsd/.*:
     mem: 90
   toolshed.g2.bx.psu.edu/repos/chemteam/bio3d_rmsf/bio3d_rmsf/.*:


### PR DESCRIPTION
this is running out of memory on Galaxy Australia. I don't know how much it needs so am giving it the same as bio3d_pca.