### PR TITLE
Try unpinning galaxy-app in linter requirements

### DIFF
--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,3 +1,3 @@
 total-perspective-vortex
 pyyaml
-galaxy-app<=22.1.1
+galaxy-app


### PR DESCRIPTION
this has been pinned down, but linting has begun to fail. If it still fails unpinned I'll look for another version to pin it on.