### PR TITLE
Limit maaslin2 1.16.0 to 1 core 

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -1364,7 +1364,7 @@ tools:
     mem: 8
   toolshed.g2.bx.psu.edu/repos/iuc/lumpy_sv/lumpy_sv/.*:
     mem: 8
-  toolshed.g2.bx.psu.edu/repos/iuc/maaslin2/maaslin2/1.16.0+galaxy0:
+  toolshed.g2.bx.psu.edu/repos/iuc/maaslin2/maaslin2/1.16.0.*:
     cores: 1
   toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_bdgdiff/.*:
     mem: 10

--- a/tools.yml
+++ b/tools.yml
@@ -1364,6 +1364,8 @@ tools:
     mem: 8
   toolshed.g2.bx.psu.edu/repos/iuc/lumpy_sv/lumpy_sv/.*:
     mem: 8
+  toolshed.g2.bx.psu.edu/repos/iuc/maaslin2/maaslin2/1.16.0+galaxy0:
+    cores: 1
   toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_bdgdiff/.*:
     mem: 10
   toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/.*:


### PR DESCRIPTION
Since this version of maaslin2 cannot handle more than 1 core, limit it. See https://github.com/galaxyproject/tools-iuc/pull/5999