### PR TITLE
more memory and fewer cores for mirdeep2

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -2640,9 +2640,10 @@ tools:
   toolshed.g2.bx.psu.edu/repos/rnateam/metilene/metilene/.*:
     cores: 10
     mem: 20
+  toolshed.g2.bx.psu.edu/repos/rnateam/mirdeep2/rbc_mirdeep2/.*:
+    mem: 8
   toolshed.g2.bx.psu.edu/repos/rnateam/mirdeep2_mapper/rbc_mirdeep2_mapper/.*:
-    cores: 10
-    mem: 20
+    mem: 28
   toolshed.g2.bx.psu.edu/repos/rnateam/paralyzer/paralyzer/.*:
     mem: 8
     env:


### PR DESCRIPTION
This has come up on Galaxy Australia because mem: 20 is not quite enough for mirdeep2_mapper and the default is not enough for mirdeep2. The wrappers make no reference to GALAXY_SLOTS so no need to set cores for these.