### PR TITLE
Change anndata_import memory for GTA

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -1138,7 +1138,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/anndata_export/anndata_export/.*:
     cores: 4
   toolshed.g2.bx.psu.edu/repos/iuc/anndata_import/anndata_import/.*:
-    mem: 2 + input_size * 10
+    mem: 4
   toolshed.g2.bx.psu.edu/repos/iuc/anndata_inspect/anndata_inspect/.*:
     mem: 15.2
   toolshed.g2.bx.psu.edu/repos/iuc/anndata_manipulate/anndata_manipulate/.*:


### PR DESCRIPTION
I have a tiny input of less than 30MB (training data from the PBMC 3k tutorial). `anndata_import` is running normally on .eu and .org.eu servers and used around 350 MB.  

The existing rule `2 + input_size * 10` should allocate some 2.x GB. But it is allocating only 277 MB on .org and failing.

Here is the history on .org with failing job:  https://usegalaxy.org/u/videmp/h/anndata-import