### PR TITLE
Remove clustalw, set fixed raxml memory

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -2274,6 +2274,7 @@ tools:
     cores: 16
   toolshed.g2.bx.psu.edu/repos/iuc/raxml/raxml/.*:
     cores: 16
+    mem: 3.7
   toolshed.g2.bx.psu.edu/repos/iuc/red/red/.*:
     mem: 8
   toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/.*:

--- a/tools.yml
+++ b/tools.yml
@@ -409,8 +409,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/.*:
     cores: 8
     mem: 30
-  toolshed.g2.bx.psu.edu/repos/devteam/clustalw/clustalw/.*:
-    mem: 34
   toolshed.g2.bx.psu.edu/repos/devteam/cuffcompare/cuffcompare/.*:
     mem: 10
   toolshed.g2.bx.psu.edu/repos/devteam/cuffdiff/cuffdiff/.*:


### PR DESCRIPTION
I am not sure what is going on here but:

- [AU allocates](https://github.com/usegalaxy-au/infrastructure/blob/549c324bdbae7502f630cdc147dd4147918bbcf2/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml#L537) from 11.5 to 30.7 GB and multiple cores, although I don't believe the wrapper supports multiple cores?
- In the shared DB (and on .org) we allocate 34 GB.

In practice on .org the histogram looks like:

```console
ndc@galaxy-db% gxadmin tsvquery tool-metrics 'toolshed.g2.bx.psu.edu/repos/devteam/clustalw/clustalw/2.1+galaxy1' memory.peak --ok | awk '{print $1 / 1024 / 1024 / 1024}' | gxadmin filter histogram
(   0.221,    0.466) n=6472  **************************************************
[   0.466,    0.711) n=131   *
[   0.711,    0.956) n=86
[   0.956,    1.201) n=47
[   1.201,    1.446) n=24
[   1.446,    1.691) n=30
[   1.691,    1.936) n=22
[   1.936,    2.181) n=23
[   2.181,    2.426) n=8
[   2.426,    2.671) n=8
[   2.671,    2.916) n=4
[   2.916,    3.161) n=4
[   3.161,    3.406) n=1
[   3.406,    3.651) n=6
[   3.651,    3.896) n=2
[   3.896,    4.141) n=4
[   4.141,    4.386) n=1
[   4.386,    4.631) n=0
[   4.631,    4.876) n=0
[   4.876,    5.121) n=2
[   5.121,    5.367) n=0
[   5.367,    5.612) n=1
[   5.612,    5.857) n=1
[   5.857,    6.102) n=1
[   6.102,    6.347) n=2
[   6.347,    6.592) n=1
[   6.592,    6.837) n=0
[   6.837,    7.082) n=0
[   7.082,    7.327) n=1
[   7.327,    7.572) n=0
[   7.572,    7.817) n=1
[   7.817,    8.062) n=0
[   8.062,    8.307) n=0
[   8.307,    8.552) n=0
[   8.552,    8.797) n=0
[   8.797,    9.042) n=0
[   9.042,    9.287) n=0
[   9.287,    9.532) n=0
[   9.532,    9.777) n=0
[   9.777,   10.022) n=1
```

Maybe old versions were much more inefficient? But it does not seem like we need to allocate anything special for the current version. I would be interested to see what memory usage looks like at EU and AU.

Also with larger inputs the tool runs forever, AU rejects anything >= 40 MB, I will update if I can determine what the rough size at which it runs forever for us is, and maybe it is worth including that in the shared DB?

raxml wants 16 cores but because of the memory factor that most people use in their default tool (see #73) is probably going to also request ~64 GB of memory despite only using ~2 GB:

```console
ndc@galaxy-db% gxadmin tsvquery tool-metrics 'toolshed.g2.bx.psu.edu/repos/iuc/raxml/raxml/8.2%' memory.peak --ok --like | awk '{print $1 / 1024 / 1024 / 1024}' | gxadmin filter histogram
(   0.226,    2.336) n=554   **************************************************
[   2.336,    4.446) n=8
[   4.446,    6.556) n=5
[   6.556,    8.666) n=5
[   8.666,   10.776) n=0
[  10.776,   12.887) n=1
[  12.887,   14.997) n=2
[  14.997,   17.107) n=0
[  17.107,   19.217) n=1
[  19.217,   21.327) n=0
[  21.327,   23.437) n=2
[  23.437,   25.548) n=1
[  25.548,   27.658) n=0
[  27.658,   29.768) n=0
[  29.768,   31.878) n=0
[  31.878,   33.988) n=1
[  33.988,   36.098) n=0
[  36.098,   38.208) n=1
```