### PR TITLE
Ease local runner use.

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -2822,6 +2822,11 @@ destinations:
       tpv_gpus: '{gpus}'
       tpv_mem: '{mem}'
     abstract: true
+  tpvdb_local:
+    params:
+      local_slots: '{cores}'
+    abstract: true
+    runner: local
   tpvdb_slurm:
     context:
       slurm_walltime: ''


### PR DESCRIPTION
I think this should work as a minimum custom local "destination" to take advantage of core rules after this change.

```
destinations:
  local:
    inherits: tpvdb_local
```