### PR TITLE
Remove rank function

### DIFF
--- a/.github/workflows/check_tpv_config.yml
+++ b/.github/workflows/check_tpv_config.yml
@@ -22,9 +22,9 @@ jobs:
         fetch-depth: 0 # number of commits to fetch. 0 indicates all history for all branches and tags
     # Set up python environment
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: "3.10"
         cache: pip
     # Install python dependencies for check_files script
     - name: Install dependencies

--- a/tools.yml
+++ b/tools.yml
@@ -12,8 +12,6 @@ tools:
       - offline
     rules: []
     abstract: true
-    rank: |
-      helpers.weighted_random_sampling(candidate_destinations)
   testtoolshed.g2.bx.psu.edu/repos/fubar/htseq_bams_to_count_matrix/htseqsams2mxlocal/.*:
     cores: 3
     mem: 11.5


### PR DESCRIPTION
Having a custom rank function causes TPV tag preferences (specifically prefer and accept) to be ignored. The weighted random behaviour may also be confusing to new users. Therefore, revert to the more predictable default behaviour of always choosing the single highest scoring destination (best tag match) and let admins explicitly override the rank function if they need more complex behaviour.