### PR TITLE
Unpin galaxy deps in favour of latest

### DIFF
--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,16 +1,3 @@
 total-perspective-vortex
 pyyaml
-galaxy-app==23.1.4
-galaxy-auth==23.1.4
-galaxy-config==23.1.4
-galaxy-data==23.1.4
-galaxy-files==23.1.4
-galaxy-job-execution==23.1.4
-galaxy-job-metrics==23.1.4
-galaxy-navigation==23.1.4
-galaxy-objectstore==23.1.4
-galaxy-tool-util==23.1.4
-galaxy-tours==23.1.4
-galaxy-util==23.1.4
-galaxy-web-framework==23.1.4
-galaxy-web-stack==23.1.4
+galaxy-app


### PR DESCRIPTION
Pin introduced in https://github.com/galaxyproject/tpv-shared-database/pull/59 should no longer be needed. Fixes action failure due to outdated pydantic: https://github.com/galaxyproject/tpv-shared-database/actions/runs/16762681677