### PR TITLE
Add kraken2 mem rule based on galaxy main

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -1466,7 +1466,48 @@ tools:
     mem: 8
   toolshed.g2.bx.psu.edu/repos/iuc/kraken2/kraken2/.*:
     cores: 2
-    mem: 70
+    mem: |
+      import os
+      import functools
+      from typing import Optional
+
+      @functools.lru_cache(maxsize=128)
+      def get_ref_size(lookup_value: str, table_name: str, lookup_column: str, value_column: str, value_template: str) -> Optional[int]:
+          ref_size = None  # optional int will be None unless set
+          try:
+              table_value = app.tool_data_tables.get(table_name).get_entry(
+                  lookup_column, lookup_value, value_column
+              )
+              if table_value is not None:
+                  table_value = value_template.format(value=table_value)
+                  ref_size = int(os.path.getsize(table_value) / 1024**3)
+                  log.debug(
+                      "Data table '%s' lookup '%s=%s: %s=%s': %s GB",
+                      table_name, lookup_column, lookup_value,
+                      value_column, table_value, ref_size
+                  )
+              else:
+                  log.warning(
+                      "Data table '%s' lookup '%s=%s: %s=None' returned None!, defaulting to %s",
+                      table_name, lookup_column, lookup_value,
+                      value_column, ref_size
+                  )
+          except OSError:
+              log.exception("Failed to get size of: %s", table_value)
+          return ref_size
+
+      default_mem = 64
+      options = job.get_param_values(app)
+      lookup_value = options["kraken2_database"]
+
+      ref_size = get_ref_size(
+        lookup_value=lookup_value,
+        table_name="kraken2_databases",
+        lookup_column="value",
+        value_column="path",
+        value_template="{value}/hash.k2d",
+      )
+      min(ref_size * 1.2 + 48, 980) if ref_size is not None else default_mem
   toolshed.g2.bx.psu.edu/repos/iuc/krakentools_extract_kraken_reads/krakentools_extract_kraken_reads/.*:
     mem: 10
   toolshed.g2.bx.psu.edu/repos/iuc/length_and_gc_content/.*:


### PR DESCRIPTION
Originally based on Galaxy Main's rule: https://github.com/galaxyproject/usegalaxy-playbook/blob/2d733399fa19456338cba8cad6ca10acccd43691/env/common/templates/galaxy/config/tpv/tools.yaml.j2#L979

Which was subsequently enhanced by @cat-bro in Galaxy AU with an lru cache: https://github.com/usegalaxy-au/infrastructure/blob/cad444008d695431248f68d65001cb5bdeb815a5/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_vortex_config.yml#L21C1-L62C77