### PR TITLE
Remove $EGGNOG_DBMEM from eggnog env vars

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -654,9 +654,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxyp/eggnog_mapper/eggnog_mapper/.*:
     cores: 8
     mem: 24
-    env:
-      EGGNOG_DBMEM: ' --dbmem '
-      SINGULARITYENV_EGGNOG_DBMEM: ' --dbmem '
   toolshed.g2.bx.psu.edu/repos/galaxyp/eggnog_mapper/eggnog_mapper_search/.*:
     cores: 4
     mem: 20


### PR DESCRIPTION
Galaxy Australia gives each eggnog job 32GB of RAM. The presence of `—dbmem` (introduced recently) in the command line causes the db to be loaded to memory. GA has strict OOM killing and all eggnog jobs since this change have been OOM killed. I’m about to try overriding this in our local config.