### PR TITLE
Refactor memory settings in tools.yml

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -2886,11 +2886,11 @@ tools:
     - id: tpvdb_metaspades_small_input_rule
       if: 0.05 <= input_size < 1
       cores: 8
-      mem: 100
+      mem: 25.3 + 13.3 * input_size
     - id: tpvdb_metaspades_medium_input_rule
       if: 1 <= input_size < 60
       cores: 16
-      mem: 350
+      mem: 25.3 + 13.3 * input_size
     - id: tpvdb_metaspades_big_input_rule
       if: input_size >= 60
       fail: Too much data, please don't use Spades for this

--- a/tools.yml
+++ b/tools.yml
@@ -2886,11 +2886,11 @@ tools:
     - id: tpvdb_metaspades_small_input_rule
       if: 0.05 <= input_size < 1
       cores: 8
-      mem: 25.3 + 13.3 * input_size
+      mem: min((25.3 + 13.3 * input_size),350)
     - id: tpvdb_metaspades_medium_input_rule
       if: 1 <= input_size < 60
       cores: 16
-      mem: 25.3 + 13.3 * input_size
+      mem: min((25.3 + 13.3 * input_size),350)
     - id: tpvdb_metaspades_big_input_rule
       if: input_size >= 60
       fail: Too much data, please don't use Spades for this


### PR DESCRIPTION
Updated memory allocation formulas for input size rules.
We investigated the memory usage of metaspades for the FAIRyMAGs project and compared the current heuristic vs a linear file size-based approach.
This new rule should save a lot of memory as compared to setting 350 GB for anything with input > 1GB.
The analysis was done for v3.15.3 but newer versions are supposed to be more memory efficient, so this rule should be even more effective.

<img width="790" height="590" alt="image" src="https://github.com/user-attachments/assets/7800d4ed-e133-4f33-9d2e-e2553edb1602" />
