### PR TITLE
Increase memory allocation for bedtools_sortbed

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -1266,7 +1266,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_mergebed/.*:
     mem: 15
   toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/.*:
-    mem: 20
+    mem: 30
   toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_subtractbed/.*:
     mem: 8
   toolshed.g2.bx.psu.edu/repos/iuc/bellerophon/bellerophon/.*:


### PR DESCRIPTION
We found that some smaller-ish jobs ran out of memory (28GB), so increase just a bit the amount.

Note: unclear to me if this kind of modification (which is not additive) is valuable for everyone since every site has different hardware. I've made a specialization rule in [our case](https://github.com/usegalaxy-ca/usegalaxy.ca/commit/85858c0638ae78d975fd72d4afd03dc36daac03e), but this kind of modification is always pushing smaller jobs onto bigger hardware.